### PR TITLE
Profile Picture Recipient Description: Use them instead of him

### DIFF
--- a/Resources/Strings/en.lproj/Localizable.strings
+++ b/Resources/Strings/en.lproj/Localizable.strings
@@ -411,7 +411,7 @@
 "no_contacts_syncoff" = "You don't have any contacts yet. Turn on synchronization (Settings > Privacy), or add contacts manually using the + button.";
 "no_contacts_permission_message" = "Threema does not have permission to access your contacts. Please go to your device's privacy settings and enable contacts access for Threema.";
 
-"contact_added_to_profilepicture_list" = "This contact will receive your profile picture when you write him.";
+"contact_added_to_profilepicture_list" = "This contact will receive your profile picture when you write them.";
 "contact_removed_from_profilepicture_list" = "This contact will no longer receive your profile.";
 "contact_send_profilepicture_success" = "Your profile picture has been successfully sent to the contact.";
 "contact_send_profilepicture_error" = "Your profile picture could not be sent. Please try again later.";


### PR DESCRIPTION
## Description

Use them for profile picture localization as it is used for other strings.

## Checklist

<!-- Please check the items that apply. -->

- [x] I signed the [Contributor License Agreement](https://threema.ch/en/open-source/cla)
- [x] All changes in this pull request were made by me, I own the full copyright
      for all these changes
